### PR TITLE
from typing import Text on Python >= 3.5.2

### DIFF
--- a/onnx2caffe/_operators.py
+++ b/onnx2caffe/_operators.py
@@ -8,7 +8,12 @@ import numpy as np
 from ._graph import Node, Graph
 from MyCaffe import Function as myf
 
-def _compare(a, b, encoding="utf8"): #type: (Text, Text, Text) -> bool
+try:
+    from typing import Text
+except ImportError:
+    pass  # Python < 3.5.2
+
+def _compare(a, b, encoding="utf8"):  # type: (Text, Text, Text) -> bool
     if isinstance(a, bytes):
         a = a.decode(encoding)
     if isinstance(b, bytes):


### PR DESCRIPTION
https://docs.python.org/3/library/typing.html#typing.Text

[flake8](http://flake8.pycqa.org) testing of https://github.com/MTlab/onnx2caffe on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./onnx2caffe/_operators.py:11:38: F821 undefined name 'Text'
def _compare(a, b, encoding="utf8"): #type: (Text, Text, Text) -> bool
                                     ^
./onnx2caffe/_operators.py:11:38: F821 undefined name 'Text'
def _compare(a, b, encoding="utf8"): #type: (Text, Text, Text) -> bool
                                     ^
./onnx2caffe/_operators.py:11:38: F821 undefined name 'Text'
def _compare(a, b, encoding="utf8"): #type: (Text, Text, Text) -> bool
                                     ^
3     F821 undefined name 'Text'
3
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.